### PR TITLE
Fix language support bug.

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -288,7 +288,8 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
      */
     protected function createMyMenu()
     {
-        if (version_compare(
+        if (
+            version_compare(
                 Shopware::VERSION,
                 self::NEW_ENTITY_MANAGER_VERSION
             ) < 0

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -289,11 +289,11 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
     protected function createMyMenu()
     {
         if (version_compare(
-            Shopware::VERSION,
-            self::NEW_ENTITY_MANAGER_VERSION
-        ) < 0
+                Shopware::VERSION,
+                self::NEW_ENTITY_MANAGER_VERSION
+            ) < 0
         ) {
-            $parentMenu = $this->Menu()->findOneBy(array('id', self::MENU_PARENT_ID));
+            $parentMenu = $this->Menu()->findOneBy('id', self::MENU_PARENT_ID);
         } else {
             $parentMenu = $this->Menu()->findOneBy(array('id' => self::MENU_PARENT_ID));
         }

--- a/Components/Helper/Image.php
+++ b/Components/Helper/Image.php
@@ -103,7 +103,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Helper_Image
      */
     private static function buildUrl(
         \Shopware\Models\Article\Image $image,
-        MediaServiceInterface $mediaService,
+        MediaServiceInterface $mediaService = null,
         Shop $shop
     ) {
         $url = null;
@@ -145,7 +145,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Helper_Image
             /** @var MediaServiceInterface $mediaService */
             $mediaService = Shopware()->Container()->get('shopware_media.media_service');
         } catch (\Exception $error) {
-            $mediaService = false;
+            $mediaService = null;
         }
 
         /** @var Shopware\Models\Article\Image $image */

--- a/Components/Model/Product.php
+++ b/Components/Model/Product.php
@@ -291,6 +291,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product
      */
     public function amendArticleTranslation(\Shopware\Models\Article\Article $article, Shop $shop = null)
     {
+        /** @var \Doctrine\ORM\QueryBuilder|QueryBuilder $builder */
         $builder = Shopware()->Models()->createQueryBuilder();
         $builder = $builder->select(array('translations'))
             ->from(\Shopware\Models\Translation\Translation::class, 'translations')

--- a/Components/Model/Product.php
+++ b/Components/Model/Product.php
@@ -268,6 +268,8 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product
 
         $this->amendRatingsAndReviews($article, $shop);
         $this->amendInventoryLevel($article);
+        $this->amendArticleTranslation($article, $shop);
+
         Shopware()->Events()->notify(
             __CLASS__ . '_AfterLoad',
             array(
@@ -276,6 +278,44 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product
                 'shop' => $shop,
             )
         );
+    }
+
+    /**
+     * update Article fields to translated text based on the shop id.
+     *
+     * @param Article $article article to be updated
+     * @param Shop|null $shop sub shop id
+     */
+    public function amendArticleTranslation(\Shopware\Models\Article\Article $article, Shop $shop = null)
+    {
+        $builder = Shopware()->Models()->createQueryBuilder();
+        $builder = $builder->select(array('translations'))
+            ->from(\Shopware\Models\Translation\Translation::class, 'translations')
+            ->where('translations.key = :articleId')->setParameter('articleId', $article->getId())
+            ->andWhere('translations.type = \'article\'');
+
+        if ($shop !== null && $shop->getId() !== null) {
+            $builder = $builder->andWhere('translations.shopId = :shopId')
+                ->setParameter('shopId', $shop->getId());
+        }
+        $query = $builder->getQuery();
+        $result = $query->getOneOrNullResult();
+
+        if ($result instanceof \Shopware\Models\Translation\Translation && $result->getData()) {
+            $dataObject = unserialize($result->getData());
+            if (array_key_exists("txtArtikel", $dataObject)) {
+                $article->setName($dataObject["txtArtikel"]);
+                $this->setName($article->getName());
+            }
+            if (array_key_exists("txtshortdescription", $dataObject)) {
+                $article->setDescription($dataObject["txtshortdescription"]);
+                $this->setShortDescription($article->getDescription());
+            }
+            if (array_key_exists("txtlangbeschreibung", $dataObject)) {
+                $article->setDescriptionLong($dataObject["txtlangbeschreibung"]);
+                $this->setDescription($article->getDescriptionLong());
+            }
+        }
     }
 
     /**
@@ -317,7 +357,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product
         }
         if ($voteCount > 0) {
             $voteSum = array_sum($votes);
-            $voteAvg = round($voteSum/$voteCount, 1);
+            $voteAvg = round($voteSum / $voteCount, 1);
             $this->setRatingValue($voteAvg);
             $this->setReviewCount($voteCount);
         }

--- a/Components/Model/Product.php
+++ b/Components/Model/Product.php
@@ -257,7 +257,10 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product
         $this->availability = $this->checkAvailability($article);
         $this->tags = TagHelper::buildProductTags($article, $shop);
         $this->categories = $this->buildCategoryPaths($article, $shop);
-        $this->supplierCost = $article->getMainDetail()->getPurchasePrice();
+        //purchase price is not available before version 5.2
+        if (method_exists($article->getMainDetail(), "getPurchasePrice")) {
+            $this->supplierCost = $article->getMainDetail()->getPurchasePrice();
+        }
         $this->shortDescription = $article->getDescription();
         $this->description = $article->getDescriptionLong();
         if ($article->getSupplier() instanceof \Shopware\Models\Article\Supplier) {

--- a/Components/Operation/Product.php
+++ b/Components/Operation/Product.php
@@ -59,7 +59,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Operation_Product
             if ($shop instanceof Shopware\Models\Shop\Shop === false) {
                 continue;
             }
-            $shop->registerResources();
+            $shop->registerResources(Shopware()->Bootstrap());
             $model = new Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product();
             $model->loadData($article, $shop);
             if ($model->getProductId()) {
@@ -144,7 +144,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Operation_Product
             if ($shop instanceof Shopware\Models\Shop\Shop === false) {
                 continue;
             }
-            $shop->registerResources();
+            $shop->registerResources(Shopware()->Bootstrap());
             $model = new Shopware_Plugins_Frontend_NostoTagging_Components_Model_Product();
             $model->loadData($article, $shop);
             if ($model->getProductId()) {

--- a/Controllers/backend/NostoTagging.php
+++ b/Controllers/backend/NostoTagging.php
@@ -129,7 +129,7 @@ class Shopware_Controllers_Backend_NostoTagging extends Shopware_Controllers_Bac
             if ($shop instanceof Shopware\Models\Shop\Shop === false) {
                 continue;
             }
-            $shop->registerResources();
+            $shop->registerResources(Shopware()->Bootstrap());
             $account = NostoComponentAccount::findAccount($shop);
             if (isset($oauthParams[$shop->getId()])) {
                 $params = $oauthParams[$shop->getId()];
@@ -179,7 +179,7 @@ class Shopware_Controllers_Backend_NostoTagging extends Shopware_Controllers_Bac
         $identity = Shopware()->Auth()->getIdentity();
 
         if (!is_null($shop)) {
-            $shop->registerResources();
+            $shop->registerResources(Shopware()->Bootstrap());
             try {
                 $account = NostoComponentAccount::createAccount(
                     $shop,
@@ -239,7 +239,7 @@ class Shopware_Controllers_Backend_NostoTagging extends Shopware_Controllers_Bac
         $identity = Shopware()->Auth()->getIdentity();
 
         if (!is_null($account) && !is_null($shop)) {
-            $shop->registerResources();
+            $shop->registerResources(Shopware()->Bootstrap());
             NostoComponentAccount::removeAccount($account);
             $success = true;
             $data = array(
@@ -279,7 +279,7 @@ class Shopware_Controllers_Backend_NostoTagging extends Shopware_Controllers_Bac
         $locale = Shopware()->Auth()->getIdentity()->locale;
 
         if (!is_null($shop)) {
-            $shop->registerResources();
+            $shop->registerResources(Shopware()->Bootstrap());
             $meta = new Shopware_Plugins_Frontend_NostoTagging_Components_Meta_Oauth();
             $meta->loadData($shop, $locale);
             $client = new NostoOAuthClient($meta);


### PR DESCRIPTION
It fixed the language sub shop issue. It gets the translated product name, product short description and long description based on shop id. And because Shopware doesn't fire event when a Translation object has been added/updated/deleted, so that the product name/description translation will not be updated to nosto if shop admin adds translation to the product name/description without changing other product information.