### PR TITLE
Handle exception on non-existent service

### DIFF
--- a/Components/Order/Confirmation.php
+++ b/Components/Order/Confirmation.php
@@ -65,7 +65,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Order_Confirmation
             $shop = Shopware()->Shop();
         } catch (Exception $e) {
             // Shopware throws an exception if service does not exist
-            return;
+            $shop = $order->getShop();
         }
         
         if (is_null($shop)) {

--- a/Components/Order/Confirmation.php
+++ b/Components/Order/Confirmation.php
@@ -61,7 +61,13 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Order_Confirmation
      */
     public function sendOrder(Shopware\Models\Order\Order $order)
     {
-        $shop = Shopware()->Shop();
+        try {
+            $shop = Shopware()->Shop();
+        } catch (Exception $e) {
+            // Shopware throws an exception if service does not exist
+            return;
+        }
+        
         if (is_null($shop)) {
             return;
         }


### PR DESCRIPTION
Hi.

There's a bug in "onPostUpdateOrder" listener which makes it impossible to modify Order in APIs and command tools.

To replicate the issue create a shopware command with following content
```
$orderId = '[put any order ID here]';
$order = Shopware()->Models()->find(Order::class, $orderId);
$order->setComment('blah2');

Shopware()->Models()->persist($order);
Shopware()->Models()->flush();
```

Please check my solution for that issue.