### PR TITLE
Fix tax calculation

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -86,7 +86,7 @@ use Nosto\Nosto;
 class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     const PLATFORM_NAME = 'shopware';
-    const PLUGIN_VERSION = '2.3.1';
+    const PLUGIN_VERSION = '2.3.2';
     const MENU_PARENT_ID = 23;  // Configuration
     const NEW_ENTITY_MANAGER_VERSION = '5.0.0';
     const NEW_ATTRIBUTE_MANAGER_VERSION = '5.2.0';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.2
+- Fix tax calculation for Nosto product price to factor in the tax rules instead of only the default tax 
+
 ## 2.3.1
 - Bump Nosto SDK version to fix the double encoded Oauth redirect URL 
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": [
     "BSD-3-Clause"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "require": {
     "php": ">=5.4.0",
     "nosto/php-sdk": "3.9.1"


### PR DESCRIPTION
## Description
* We used to apply only the default tax when calculating the product price including tax
* The fix was to apply all rules (additional tax rules) 

![shopware_5_4_0_dev__rev__290328060__-_backend__c__shopware_ag](https://user-images.githubusercontent.com/15191701/51746387-9f44df00-20ae-11e9-86fc-a71b225d5812.png)

## Related Issue
closes #207

## How Has This Been Tested?
* Tested locally with setting multiple tax rules, removing additional tax rules (fallback to default tax) and enabling / disabling the setting for displaying product prices including tax 

## Documentation:
ToDo 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers