### PR TITLE
Hotfix - 2.4.1 - Add nullcheck to cart line item

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -86,7 +86,7 @@ use Nosto\Nosto;
 class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     const PLATFORM_NAME = 'shopware';
-    const PLUGIN_VERSION = '2.4.0';
+    const PLUGIN_VERSION = '2.4.1';
     const MENU_PARENT_ID = 23;  // Configuration
     const NEW_ENTITY_MANAGER_VERSION = '5.0.0';
     const NEW_ATTRIBUTE_MANAGER_VERSION = '5.2.0';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.1
+- Fix an issue that can cause crash when a product added to cart no longer has a parent 
+
 ## 2.4.0
 - Encode HTML characters automatically
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": [
     "BSD-3-Clause"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1",
   "require": {
     "php": ">=5.4.0",
     "nosto/php-sdk": "3.12.1"


### PR DESCRIPTION
## Description
An error has been reported due to missing a parent product in the line item when added to cart.
This PR adds an extra null check that if the article added to cart has no parent, skips the product id and logs the message.

## Related Issue
Fixes #221 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?


## Checklist:

- [X] My code follows the code style of this project.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
