### PR TITLE
Remove excessive loggin when confirming order via Shopware API

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -86,7 +86,7 @@ use Nosto\Nosto;
 class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     const PLATFORM_NAME = 'shopware';
-    const PLUGIN_VERSION = '2.4.6';
+    const PLUGIN_VERSION = '2.4.7';
     const MENU_PARENT_ID = 23;  // Configuration
     const NEW_ENTITY_MANAGER_VERSION = '5.0.0';
     const NEW_ATTRIBUTE_MANAGER_VERSION = '5.2.0';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.7
+- Fix sending invalid orders to Nosto by setting missing ISO code for customer country
+- Remove excessive logging in order confirmation via API operations
+
 ## 2.4.6
 - Fix an error where in some installations the plugin source path it is saved incorrectly
 

--- a/Components/Customer.php
+++ b/Components/Customer.php
@@ -86,15 +86,20 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Customer
                 ->Models()
                 ->getRepository('\Shopware\CustomModels\Nosto\Customer\Customer')
                 ->findOneBy(array('sessionId' => $sessionId));
+            $shouldPersist = false;
             if (empty($customer)) {
                 $customer = new Customer();
                 $customer->setSessionId($sessionId);
+                $shouldPersist = true;
             }
             if ($nostoId !== $customer->getNostoId()) {
                 $customer->setNostoId($nostoId);
+                $shouldPersist = true;
             }
-            Shopware()->Models()->persist($customer);
-            Shopware()->Models()->flush($customer);
+            if ($shouldPersist) {
+                Shopware()->Models()->persist($customer);
+                Shopware()->Models()->flush($customer);
+            }
         }
     }
 

--- a/Components/Model/Order/Buyer.php
+++ b/Components/Model/Order/Buyer.php
@@ -81,7 +81,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Buyer extend
                     $this->setLastName($address->getLastname());
                     $this->setPostCode($address->getZipCode());
                     $this->setPhone($address->getPhone());
-                    $this->setCountry($address->getCountry()->getName());
+                    $this->setCountry($address->getCountry()->getIso());
                 }
             } else {
                 /** @phan-suppress-next-line UndeclaredTypeInInlineVar */

--- a/Components/Order/Confirmation.php
+++ b/Components/Order/Confirmation.php
@@ -64,8 +64,6 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Order_Confirmation
             // Shopware throws an exception if service does not exist.
             // This would be the case when using Shopware API or cli
             $shop = $order->getShop();
-            /** @noinspection PhpUndefinedMethodInspection */
-            Shopware()->Plugins()->Frontend()->NostoTagging()->getLogger()->error($e->getMessage());
         }
         if ($shop === null) {
             return;
@@ -92,7 +90,11 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Order_Confirmation
                     $orderConfirmation->send($model, $customerId);
                 } catch (\Exception $e) {
                     /** @noinspection PhpUndefinedMethodInspection */
-                    Shopware()->Plugins()->Frontend()->NostoTagging()->getLogger()->error($e->getMessage());
+                    Shopware()->Plugins()->Frontend()->NostoTagging()->getLogger()->error(
+                        sprintf("Nosto order confirmation failed. Messa was: %s",
+                            $e->getMessage()
+                        )
+                    );
                 }
             }
         }

--- a/Components/Order/Confirmation.php
+++ b/Components/Order/Confirmation.php
@@ -91,7 +91,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Order_Confirmation
                 } catch (\Exception $e) {
                     /** @noinspection PhpUndefinedMethodInspection */
                     Shopware()->Plugins()->Frontend()->NostoTagging()->getLogger()->error(
-                        sprintf("Nosto order confirmation failed. Messa was: %s",
+                        sprintf("Nosto order update upsert failed. Message was: %s",
                             $e->getMessage()
                         )
                     );

--- a/Components/Order/Confirmation.php
+++ b/Components/Order/Confirmation.php
@@ -39,6 +39,7 @@ use Nosto\Operation\OrderConfirm as NostoOrderConfirmation;
 use Shopware\Models\Attribute\Order as OrderAttribute;
 use Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order as NostoOrderModel;
 use Shopware\Models\Order\Order as OrderModel;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * Order confirmation component. Used to send order information to Nosto.
@@ -60,10 +61,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Order_Confirmation
     {
         try {
             $shop = Shopware()->Shop();
-        } catch (\Exception $e) {
+        } catch (ServiceNotFoundException $e) {
+            $shop = $order->getShop();
             // Shopware throws an exception if service does not exist.
             // This would be the case when using Shopware API or cli
-            $shop = $order->getShop();
+        } catch (\Exception $e) {
+            /** @noinspection PhpUndefinedMethodInspection */
+            Shopware()->Plugins()->Frontend()->NostoTagging()->getLogger()->error($e->getMessage());
+            return;
         }
         if ($shop === null) {
             return;

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": [
     "BSD-3-Clause"
   ],
-  "version": "2.4.6",
+  "version": "2.4.7",
   "require": {
     "php": ">=5.4.0",
     "nosto/php-sdk": "3.15.0"


### PR DESCRIPTION
## Description
Remove unnecessary logging
Fix missing ISO code in customer buyer object, which would invalidate orders

## Related Issue
Closes #244 

## Motivation and Context
Excessive and unnecessary logging

## How Has This Been Tested?
PUT this:
```json
{
    "paymentStatusId": 10,
    "orderStatusId": 8,
    "trackingCode": "237948723894789234",
    "comment": "Neuer Kommentar",
    "transactionId": "0",
    "clearedDate": "2019-10-18T17:58:17+0000"
}
```
http://shopware.dev.nos.to:8080/api/orders/15?XDEBUG_SESSION_START=PHPSTORM
with stock sample data.

Check the logs
## Documentation:
N/A

## Checklist:
- [x] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
