### PR TITLE
Disable caching/hole punch for tagging

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -1031,6 +1031,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      * @see Shopware_Controllers_Frontend_NostoTagging::noCacheTaggingAction
+     * @return NostoCustomerModel|null
      */
     public function generateCustomerTagging()
     {
@@ -1059,6 +1060,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
      * something in the cart.
      *
      * @see Shopware_Controllers_Frontend_NostoTagging::noCacheTaggingAction
+     * @return NostoCartModel|null
      */
     public function generateCartTagging()
     {
@@ -1091,6 +1093,7 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
      * Generates the variation tagging data to be added to the view.
      *
      * @see Shopware_Controllers_Frontend_NostoTagging::noCacheTaggingAction
+     * @return MarkupableString|null
      */
     public function generateVariationTagging()
     {

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -86,7 +86,7 @@ use Nosto\Nosto;
 class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     const PLATFORM_NAME = 'shopware';
-    const PLUGIN_VERSION = '2.4.7';
+    const PLUGIN_VERSION = '2.4.8';
     const MENU_PARENT_ID = 23;  // Configuration
     const NEW_ENTITY_MANAGER_VERSION = '5.0.0';
     const NEW_ATTRIBUTE_MANAGER_VERSION = '5.2.0';

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -968,9 +968,6 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
         $view->extendsTemplate('frontend/plugins/nosto_tagging/index.tpl');
 
         $this->addEmbedScript($view);
-        $this->addCustomerTagging($view);
-        $this->addCartTagging($view);
-        $this->addVariationTagging($view);
         $this->addHcidTagging($view);
 
         $locale = Shopware()->Shop()->getLocale()->getLocale();
@@ -1024,20 +1021,18 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
     }
 
     /**
-     * Adds the logged in customer tagging to the view.
+     * Generates the logged in customer tagging data to be added the view.
      *
      * This tagging should be present on all pages as long as a logged in
      * customer can be found.
-     *
-     * @param Enlight_View_Default $view the view.
      *
      * @throws Enlight_Event_Exception
      * @throws ORMException
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
-     * @see Shopware_Plugins_Frontend_NostoTagging_Bootstrap::onPostDispatchFrontend
+     * @see Shopware_Controllers_Frontend_NostoTagging::noCacheTaggingAction
      */
-    protected function addCustomerTagging(Enlight_View_Default $view)
+    public function generateCustomerTagging()
     {
         /** @var Shopware\Models\Customer\Customer $customer */
         /** @noinspection PhpUndefinedFieldInspection */
@@ -1051,22 +1046,21 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
                 ->get(self::CONFIG_SEND_CUSTOMER_DATA);
         if ($customerDataAllowed && $customer instanceof CustomerModel) {
             $nostoCustomer = new NostoCustomerModel();
-            $nostoCustomer->loadData($customer);
-            $view->assign('nostoCustomer', $nostoCustomer);
+            $nostoCustomer->loadData($customer); // Do not return directly, needs to be built in this context
+            return $nostoCustomer;
         }
+        return null;
     }
 
     /**
-     * Adds the shopping cart tagging to the view.
+     * Generates the shopping cart tagging data to be added the view.
      *
      * This tagging should be present on all pages as long as the user has
      * something in the cart.
      *
-     * @param Enlight_View_Default $view the view.
-     * @suppress PhanDeprecatedFunction
-     * @see Shopware_Plugins_Frontend_NostoTagging_Bootstrap::onPostDispatchFrontend
+     * @see Shopware_Controllers_Frontend_NostoTagging::noCacheTaggingAction
      */
-    protected function addCartTagging(Enlight_View_Default $view)
+    public function generateCartTagging()
     {
         /** @var Shopware\Models\Order\Basket[] $baskets */
         /** @noinspection PhpUndefinedMethodInspection */
@@ -1079,14 +1073,12 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
         );
 
         $nostoCart = new NostoCartModel();
-        $nostoCart->loadData($baskets);
-        $view->assign('nostoCart', $nostoCart);
+        $nostoCart->loadData($baskets); // Do not return directly, needs to be built in this context
+        return $nostoCart;
     }
 
     /**
      * Adds the hcid tagging for cart and customer.
-     *
-     * @param Enlight_View_Default $view the view.
      *
      * @see Shopware_Plugins_Frontend_NostoTagging_Bootstrap::onPostDispatchFrontend
      */
@@ -1096,21 +1088,19 @@ class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Componen
     }
 
     /**
-     * Adds the variation tagging.
+     * Generates the variation tagging data to be added to the view.
      *
-     * @param Enlight_View_Default $view the view.
-     *
-     * @see Shopware_Plugins_Frontend_NostoTagging_Bootstrap::onPostDispatchFrontend
+     * @see Shopware_Controllers_Frontend_NostoTagging::noCacheTaggingAction
      */
-    protected function addVariationTagging(Enlight_View_Default $view)
+    public function generateVariationTagging()
     {
         if (CurrencyHelper::isMultiCurrencyEnabled(Shopware()->Shop())) {
-            $variationObj = new MarkupableString(
+            return new MarkupableString(
                 CurrencyHelper::getCurrentCurrencyCode(),
                 'nosto_variation'
             );
-            $view->assign('nostoVariation', $variationObj);
         }
+        return null;
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.8
+- Prevent Shopware's full page cache to cache Nosto tagging blocks
+
 ## 2.4.7
 - Fix sending invalid orders to Nosto by setting missing ISO code for customer country
 - Remove excessive logging in order confirmation via API operations

--- a/Controllers/frontend/NostoTagging.php
+++ b/Controllers/frontend/NostoTagging.php
@@ -383,7 +383,7 @@ class Shopware_Controllers_Frontend_NostoTagging extends Enlight_Controller_Acti
         $nostoFrontEnd = Shopware()->Plugins()->Frontend()->NostoTagging();
         $cartTagging = $nostoFrontEnd->generateCartTagging();
         if ($cartTagging) {
-            $html = $cartTagging->toHtml();
+            $html .= $cartTagging->toHtml();
         }
         $customerTagging = $nostoFrontEnd->generateCustomerTagging();
         if ($customerTagging) {

--- a/Controllers/frontend/NostoTagging.php
+++ b/Controllers/frontend/NostoTagging.php
@@ -369,4 +369,30 @@ class Shopware_Controllers_Frontend_NostoTagging extends Enlight_Controller_Acti
             'action' => 'index'
         ]);
     }
+
+    /**
+     * Echoes the tagging data to the template using action tags
+     * @see https://developers.shopware.com/blog/2016/07/11/on-action-tags/
+     * @throws Exception
+     */
+    public function noCacheTaggingAction()
+    {
+        $this->Front()->Plugins()->ViewRenderer()->setNoRender(true);
+        $html = '';
+        /** @noinspection PhpUndefinedMethodInspection */
+        $nostoFrontEnd = Shopware()->Plugins()->Frontend()->NostoTagging();
+        $cartTagging = $nostoFrontEnd->generateCartTagging();
+        if ($cartTagging) {
+            $html = $cartTagging->toHtml();
+        }
+        $customerTagging = $nostoFrontEnd->generateCustomerTagging();
+        if ($customerTagging) {
+            $html .= $customerTagging->toHtml();
+        }
+        $variationTagging = $nostoFrontEnd->generateVariationTagging();
+        if ($variationTagging) {
+            $html .= $variationTagging->toHtml();
+        }
+        echo $html;
+    }
 }

--- a/Views/frontend/plugins/nosto_tagging/index.tpl
+++ b/Views/frontend/plugins/nosto_tagging/index.tpl
@@ -127,17 +127,8 @@
     {/if}
 {/block}
 {block name="frontend_index_content" append}
-    {* Needs to be rendered at template level to avoid cache issues *}
-    {if isset($nostoCustomer) && $nostoCustomer}
-        {$nostoCustomer->toHtml()}
-    {/if}
-    {if isset($nostoCart) && $nostoCart}
-        {$nostoCart->toHtml()}
-    {/if}
+    {action controller=nostoTagging action=noCacheTagging}
     {if isset($nostoPageType) && $nostoPageType}
         {$nostoPageType->toHtml()}
-    {/if}
-    {if isset($nostoVariation) && $nostoVariation}
-        {$nostoVariation->toHtml()}
     {/if}
 {/block}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": [
     "BSD-3-Clause"
   ],
-  "version": "2.4.7",
+  "version": "2.4.8",
   "require": {
     "php": ">=5.4.0",
     "nosto/php-sdk": "3.15.0"


### PR DESCRIPTION
## Motivation and Context
Shopware's full page cache is caching our tagging. This PR uses action tags that generate ESI tags, which calls the frontend controller to render the tagging. This avoids all cache mechanisms.

## How Has This Been Tested?
Tested locally and on Plugintest with Shopware's FPC

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
