### PR TITLE
Add a null guard or getting custom fields configuration

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -86,7 +86,7 @@ use Nosto\Nosto;
 class Shopware_Plugins_Frontend_NostoTagging_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     const PLATFORM_NAME = 'shopware';
-    const PLUGIN_VERSION = '2.4.8';
+    const PLUGIN_VERSION = '2.4.9';
     const MENU_PARENT_ID = 23;  // Configuration
     const NEW_ENTITY_MANAGER_VERSION = '5.0.0';
     const NEW_ATTRIBUTE_MANAGER_VERSION = '5.2.0';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.9
+- Add null guard for fetching custom fields configuration for a product
+
 ## 2.4.8
 - Prevent Shopware's full page cache to cache Nosto tagging blocks
 

--- a/Components/Helper/CustomFields.php
+++ b/Components/Helper/CustomFields.php
@@ -80,15 +80,18 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Helper_CustomFields
         $settingsCustomFields = array();
         // Add variant configuration group options into custom attributes
         try {
-            $configurator = $detail->getConfiguratorOptions()->getValues();
-            foreach ($configurator as $config) {
-                /** @var Option $config */
-                if (!$config instanceof Option
-                    || $config->getGroup() === null
-                ) {
-                    continue;
+            $configuratorOptions = $detail->getConfiguratorOptions();
+            if ($configuratorOptions !== null) {
+                $configurator = $configuratorOptions->getValues();
+                foreach ($configurator as $config) {
+                    /** @var Option $config */
+                    if (!$config instanceof Option
+                        || $config->getGroup() === null
+                    ) {
+                        continue;
+                    }
+                    $settingsCustomFields[$config->getGroup()->getName()] = $config->getName();
                 }
-                $settingsCustomFields[$config->getGroup()->getName()] = $config->getName();
             }
         } catch (\Exception $e) {
             /** @noinspection PhpUndefinedMethodInspection */

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": [
     "BSD-3-Clause"
   ],
-  "version": "2.4.8",
+  "version": "2.4.9",
   "require": {
     "php": ">=5.4.0",
     "nosto/php-sdk": "3.15.0"


### PR DESCRIPTION
## Description
Add a null guard for `Detail::getConfiguratorOptions`

## Related Issue
#248 

## Motivation and Context
This might throw a fatal error 

## How Has This Been Tested?
Tested locally

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
