### PR TITLE
check if payment instance available

### DIFF
--- a/Components/Model/Order.php
+++ b/Components/Model/Order.php
@@ -71,8 +71,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order extends Nost
         try {
             $paymentProvider = $payment->getName();
             $paymentPlugin = $payment->getPlugin();
-            if ($paymentPlugin !== null && $paymentPlugin->getVersion()) {
-                $paymentProvider .= sprintf(' [%s]', $paymentPlugin->getVersion());
+            if ($payment instanceof \Shopware\Models\Payment\Payment) {
+                $paymentProvider = $payment->getName();
+                $paymentPlugin = $payment->getPlugin();
+                if ($paymentPlugin !== null && $paymentPlugin->getVersion()) {
+                    $paymentProvider .= sprintf(' [%s]', $paymentPlugin->getVersion());
+                }
+            } else {
+                throw new \InvalidArgumentException(sprintf("Could not determine payment method of order %s", $order->getNumber()));
             }
         } catch (Exception $e) {
             $paymentProvider = 'unknown';


### PR DESCRIPTION
Check if there is an payment instance and throw an exception instead. Otherwise you get an fatal error.

<!--- Provide a general summary of your changes in the Title above -->

## Description
We are facing issues like Call to a member function getName() on null NostoTagging/Components/Model/Order.php:73

## Motivation and Context
The issue should be logged instead of break

## How Has This Been Tested?
on production

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
